### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
+>📢 This repository has been archived and is no longer maintained.
+>
+>If you wish to continue using or contributing to the open-source version of this project, please visit the actively maintained repository here:
+>👉 [https://github.com/bmc-toolbox/common](https://github.com/bmc-toolbox/common)
+>
+>Thank you for your interest and support!
+
+
 Package common is intended to provide a common data structure to model
 server hardware and its component attributes between libraries/tools.


### PR DESCRIPTION
This PR updates the README.md file to inform users that this repository has been archived and is no longer maintained.

The message includes:

- A notice that the repo is archived

- A link to the actively maintained open-source repository: https://github.com/bmc-toolbox/common

This change is meant to help users find the current codebase and avoid confusion.